### PR TITLE
Link corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ How to set up a time-lapse with a Raspberry Pi using the camera module.
 
 ## Step 0: Camera setup
 
-Follow the [camera module setup guide](https://github.com/raspberrypi/documentation/tree/master/usage/camera).
+Follow the [camera module setup guide](/documentation/usage/camera).
 
 ## Step 1: Test the camera
 
@@ -146,19 +146,19 @@ If your monitor is attached, you can use `ls`, `watch ls` and even the file brow
 
 #### SSH
 
-You can gain remote access to the command line using [SSH](ttps://github.com/raspberrypi/documentation/blob/master/remote-access/ssh/README.md) use `ls` and `watch ls` to verify the pictures are being captured.
+You can gain remote access to the command line using [SSH](/documentation/remote-access/ssh/README.md) use `ls` and `watch ls` to verify the pictures are being captured.
 
 #### SCP
 
-Use [SCP](https://github.com/raspberrypi/documentation/blob/master/remote-access/ssh/scp.md) (Secure copy) to copy files over [SSH](https://github.com/raspberrypi/documentation/blob/master/remote-access/ssh/README.md).
+Use [SCP](/documentation/remote-access/ssh/scp.md) (Secure copy) to copy files over [SSH](/documentation/remote-access/ssh/README.md).
 
 #### rsync
 
-Use [`rsync`](https://github.com/raspberrypi/documentation/blob/master/remote-access/ssh/rsync.md) to syncronise a folder on the Pi with a folder on your computer.
+Use [`rsync`](/documentation/remote-access/ssh/rsync.md) to syncronise a folder on the Pi with a folder on your computer.
 
 #### FTP
 
-Set up an [FTP](https://github.com/raspberrypi/documentation/blob/master/remote-access/ftp.md) server on the Pi and use an FTP client on another computer to access the Pi's filesystem remotely, and copy files over.
+Set up an [FTP](/documentation/remote-access/ftp.md) server on the Pi and use an FTP client on another computer to access the Pi's filesystem remotely, and copy files over.
 
 #### SD Card
 


### PR DESCRIPTION
Links should now point to documentation on the Pi site instead of GH pages (although they'll now fail to work on GH given that they're relative links pointing to files in a different repo)
